### PR TITLE
Enhance flow configuration and remove lodash

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/**/*
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
+// @flow
 import _ from 'lodash';
+
+type ReduxStore = {
+  dispatch: Function,
+  getState: () => Object
+};
 
 export type EffectParams = {
   action: Object,
@@ -9,12 +15,18 @@ export type EffectParams = {
 
 export type EffectErrorHandlerParams = {
   action: Object,
+  dispatch: (action: any) => void,
+  getState: () => any,
+  nextDispatchAsync: (actionType: string) => Promise<Object>,
   error: Object,
 };
 
+export type EffectFunction = (params: EffectParams) => Promise<any>;
+
 export type EffectDefinition = {
   action: string,
-  effect: (params: any) => Promise<any>,
+  effect: EffectFunction,
+  error?: (params: EffectErrorHandlerParams) => any
 };
 
 export const effectsMiddleware = (effectsDefinitionArray: Array<EffectDefinition>) => {
@@ -55,7 +67,7 @@ export const effectsMiddleware = (effectsDefinitionArray: Array<EffectDefinition
     }
   };
 
-  return store => next => action => {
+  return (store: ReduxStore) => (next: Function) => (action: Object) => {
     let result = next(action);
 
     _.forEach(_effects[action.type], effect => {


### PR DESCRIPTION
I would like to import the `EffectFunction` flow type in our product, so I've added that in addition to a .flowconfig file so we can run flow against the project.

I also removed lodash in a second commit. Since this library is so small the the usage of lodash is just for iterating over arrays, I removed it in favor of standard ES5 usages of `forEach` and `reduce`.
